### PR TITLE
Apply atl patches on latest nat46 fork

### DIFF
--- a/nat46/modules/Makefile
+++ b/nat46/modules/Makefile
@@ -1,5 +1,5 @@
 obj-m += nat46.o
-nat46-objs := nat46-netdev.o nat46-module.o nat46-core.o nat46-glue.o
+nat46-objs := nat46-netdev.o nat46-module.o nat46-core.o nat46-glue.o nat46-tree.o
 CFLAGS_nat46.o := -DDEBUG
 
 EXTRA_CFLAGS += -Wno-date-time

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1017,6 +1017,11 @@ static int xlate_payload6_to4(nat46_instance_t *nat46, void *pv6, void *ptrans_h
   u16 ipflags = htons(IP_DF);
   int infrag_payload_len = ntohs(ip6h->payload_len);
 
+  if (v6_len <= IPV4HDRSIZE)
+  {
+    /* The frame has not been manipulated, so just return v6_len */
+    return v6_len;
+  }
   /*
    * The packet is supposedly our own packet after translation - so the rules
    * will be swapped compared to translation of the outer packet

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -131,7 +131,7 @@ static int try_parse_ipv6_prefix(struct in6_addr *pref, int *pref_len, char *arg
   return err;
 }
 
-static int try_parse_ipv4_prefix(u32 *v4addr, int *pref_len, char *arg) {
+static int try_parse_ipv4_prefix(struct in_addr *v4addr, int *pref_len, char *arg) {
   int err = 0;
   char *arg_plen = strchr(arg, '/');
   if (arg_plen) {
@@ -184,22 +184,17 @@ static int try_parse_rule_arg(nat46_xlate_rule_t *rule, char *arg_name, char **p
  * Parse the config commands in the buffer, 
  * destructive (puts zero between the args) 
  */
-
-int nat46_set_ipair_config(nat46_instance_t *nat46, int ipair, char *buf, int count) {
+ nat46_xlate_rulepair_t *nat46_parse_config(nat46_instance_t *nat46, char *buf, int count) {
   char *tail = buf;
   char *arg_name;
   int err = 0;
   char *val;
-  nat46_xlate_rulepair_t *apair = NULL;
-
-  if ((ipair < 0) || (ipair >= nat46->npairs)) {
-    return -1;
-  }
-
-  apair = &nat46->pairs[ipair];
+  nat46_xlate_rulepair_t *new_rule = kzalloc(sizeof(nat46_xlate_rulepair_t), GFP_KERNEL);
 
   while ((0 == err) && (NULL != (arg_name = get_next_arg(&tail)))) {
     if (0 == strcmp(arg_name, "debug")) {
+      /* Having a rule by rule debug flag seems out of place - it is configuring debug
+       * mode for the whole instance. It has been left for compatibility. */
       val = get_next_arg(&tail);
       if (val) {
         nat46->debug = simple_strtol(val, NULL, 10);
@@ -207,22 +202,81 @@ int nat46_set_ipair_config(nat46_instance_t *nat46, int ipair, char *buf, int co
     } else if (arg_name == strstr(arg_name, "local.")) {
       arg_name += strlen("local.");
       nat46debug(13, "Setting local xlate parameter");
-      err = try_parse_rule_arg(&apair->local, arg_name, &tail);
+      err = try_parse_rule_arg(&new_rule->local, arg_name, &tail);
     } else if (arg_name == strstr(arg_name, "remote.")) {
       arg_name += strlen("remote.");
       nat46debug(13, "Setting remote xlate parameter");
-      err = try_parse_rule_arg(&apair->remote, arg_name, &tail);
+      err = try_parse_rule_arg(&new_rule->remote, arg_name, &tail);
     }
   }
-  return err;
+
+  if (err) {
+    kfree(new_rule);
+    new_rule = NULL;
+  }
+
+  return new_rule;
 }
 
-int nat46_set_config(nat46_instance_t *nat46, char *buf, int count) {
-  int ret = -1;
-  if (nat46->npairs > 0) {
-    ret = nat46_set_ipair_config(nat46, nat46->npairs-1, buf, count);
+int nat46_insert_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  int v4 = 0;
+  int v6 = 0;
+  if (rule->local.v4_pref_len == 0)
+  {
+    v4 = 1;
   }
-  return ret;
+  if (rule->local.v6_pref_len == 0)
+  {
+    v6 = 1;
+  }
+  tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  return 0;
+}
+
+int nat46_set_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  int v4 = 0;
+  int v6 = 0;
+  nat46_xlate_rulepair_t *old_entry;
+  if (rule->local.v4_pref_len == 0)
+  {
+    v4 = 1;
+  }
+  if (rule->local.v6_pref_len == 0)
+  {
+    v6 = 1;
+  }
+  old_entry = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
+  if (tree46_remove(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len))
+  {
+    kfree(old_entry);
+  }
+  tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  return 0;
+}
+
+int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  int v4 = 0;
+  int v6 = 0;
+  nat46_xlate_rulepair_t *old_entry_v4;
+  nat46_xlate_rulepair_t *old_entry_v6;
+  if (rule->local.v4_pref_len == 0)
+  {
+    v4 = 1;
+  }
+  if (rule->local.v6_pref_len == 0)
+  {
+    v6 = 1;
+  }
+  old_entry_v4 = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
+  old_entry_v6 = tree46_find_best_v6(&nat46->rules, (v4) ? rule->remote.v6_pref : rule->local.v6_pref);
+  if (old_entry_v4 == old_entry_v6)
+  {
+    if (tree46_remove(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len))
+    {
+      kfree(old_entry_v4);
+    }
+  }
+  return 0;
 }
 
 static char *xlate_style_to_string(nat46_xlate_style_t style) {
@@ -242,38 +296,24 @@ static char *xlate_style_to_string(nat46_xlate_style_t style) {
 /* 
  * Get the nat46 configuration into a supplied buffer (if non-null).
  */
-int nat46_get_ipair_config(nat46_instance_t *nat46, int ipair, char *buf, int count) {
+int nat46_get_config_string(nat46_instance_t *nat46, nat46_xlate_rulepair_t *pair, char *buf, int count) {
   int ret = 0;
-  nat46_xlate_rulepair_t *apair = NULL;
   char *format = "local.v4 %pI4/%d local.v6 %pI6c/%d local.style %s local.ea-len %d local.psid-offset %d remote.v4 %pI4/%d remote.v6 %pI6c/%d remote.style %s remote.ea-len %d remote.psid-offset %d debug %d";
 
-  if ((ipair < 0) || (ipair >= nat46->npairs)) {
+  if (pair == NULL) {
     return ret;
   }
-  apair = &nat46->pairs[ipair];
 
   ret = snprintf(buf, count, format,
-		&apair->local.v4_pref, apair->local.v4_pref_len,
-		&apair->local.v6_pref, apair->local.v6_pref_len,
-		xlate_style_to_string(apair->local.style),
-		apair->local.ea_len, apair->local.psid_offset,
-
-		&apair->remote.v4_pref, apair->remote.v4_pref_len,
-		&apair->remote.v6_pref, apair->remote.v6_pref_len,
-		xlate_style_to_string(apair->remote.style),
-		apair->remote.ea_len, apair->remote.psid_offset,
-
+		&pair->local.v4_pref, pair->local.v4_pref_len,
+		&pair->local.v6_pref, pair->local.v6_pref_len,
+		xlate_style_to_string(pair->local.style),
+		pair->local.ea_len, pair->local.psid_offset,
+		&pair->remote.v4_pref, pair->remote.v4_pref_len,
+		&pair->remote.v6_pref, pair->remote.v6_pref_len,
+		xlate_style_to_string(pair->remote.style),
+		pair->remote.ea_len, pair->remote.psid_offset,
 		nat46->debug);
-  return ret;
-}
-
-int nat46_get_config(nat46_instance_t *nat46, char *buf, int count) {
-  int ret = 0;
-  if (nat46->npairs > 0) {
-    ret = nat46_get_ipair_config(nat46, nat46->npairs-1, buf, count);
-  } else {
-    nat46debug(0, "nat46_get_config: npairs is 0");
-  }
   return ret;
 }
 
@@ -609,7 +649,7 @@ static int xlate_map_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule,
 
   /* check that the ipv4 address is within the IPv4 map domain and reject if not */
 
-  if ( (ntohl(*pv4u32) & (0xffffffff << v4_lsb_bits_len)) != ntohl(rule->v4_pref) ) {
+  if ( (ntohl(*pv4u32) & (0xffffffff << v4_lsb_bits_len)) != ntohl(rule->v4_pref.s_addr) ) {
     nat46debug(5, "xlate_map_v4_to_v6: IPv4 address %pI4 outside of MAP domain %pI4/%d", pipv4, &rule->v4_pref, rule->v4_pref_len);
     return 0;
   }
@@ -922,36 +962,22 @@ static int is_last_pair_in_group(nat46_xlate_rulepair_t *apair) {
 }
 
 static void pairs_xlate_v6_to_v4_inner(nat46_instance_t *nat46, struct ipv6hdr *ip6h, __u32 *pv4saddr, __u32 *pv4daddr) {
-  int ipair = 0;
-  nat46_xlate_rulepair_t *apair = NULL;
-  int xlate_src = -1;
-  int xlate_dst = -1;
+  nat46_xlate_rulepair_t *xlate_src = NULL;
+  nat46_xlate_rulepair_t *xlate_dst = NULL;
 
-  for(ipair = 0; ipair < nat46->npairs; ipair++) {
-    apair = &nat46->pairs[ipair];
+  xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
+  xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
 
-    if(-1 == xlate_dst) {
-      if(xlate_v6_to_v4(nat46, &apair->remote, &ip6h->daddr, pv4daddr)) {
-        xlate_dst = ipair;
-      }
-    }
-    if(-1 == xlate_src) {
-      if(xlate_v6_to_v4(nat46, &apair->local, &ip6h->saddr, pv4saddr)) {
-        xlate_src = ipair;
-      }
-    }
-    if((xlate_src >= 0) && (xlate_dst >= 0)) {
-      /* we did manage to translate it */
-      break;
-    } else {
-      /* We did not match fully and there are more rules */
-      if((ipair+1 < nat46->npairs) && is_last_pair_in_group(apair)) {
-        xlate_src = -1;
-        xlate_dst = -1;
-      }
-    }
+  if(xlate_dst)
+  {
+    xlate_v6_to_v4(nat46, &xlate_dst->remote, &ip6h->daddr, pv4daddr);
   }
-  nat46debug(5, "[nat46payload] xlate results: src %d dst %d", xlate_src, xlate_dst);
+  if(xlate_src)
+  {
+    xlate_v6_to_v4(nat46, &xlate_src->local, &ip6h->saddr, pv4saddr);
+  }
+
+  nat46debug(5, "[nat46payload] xlate results: src %p dst %p", xlate_src, xlate_dst);
 }
 
 /*
@@ -1534,51 +1560,38 @@ static uint16_t nat46_fixup_icmp(nat46_instance_t *nat46, struct iphdr *iph, str
 }
 
 static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *ip6h, uint16_t proto, __u32 *pv4saddr, __u32 *pv4daddr) {
-  int ipair = 0;
-  nat46_xlate_rulepair_t *apair = NULL;
-  int xlate_src = -1;
-  int xlate_dst = -1;
+  nat46_xlate_rulepair_t *xlate_src = NULL;
+  nat46_xlate_rulepair_t *xlate_dst = NULL;
 
-  for(ipair = 0; ipair < nat46->npairs; ipair++) {
-    apair = &nat46->pairs[ipair];
-
-    if(-1 == xlate_dst) {
-      if (xlate_v6_to_v4(nat46, &apair->local, &ip6h->daddr, pv4daddr)) {
-        xlate_dst = ipair;
-      }
-    }
-    if(-1 == xlate_src) {
-      if (xlate_v6_to_v4(nat46, &apair->remote, &ip6h->saddr, pv4saddr)) {
-        xlate_src = ipair;
-      }
-    }
-    if( (xlate_src >= 0) && (xlate_dst >= 0) ) {
-      break;
-    } else {
-      /* We did not match fully and there are more rules */
-      if((ipair+1 < nat46->npairs) && is_last_pair_in_group(apair)) {
-        xlate_src = -1;
-        xlate_dst = -1;
-      }
-    }
+  xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
+  xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
+  if(xlate_dst)
+  {
+    xlate_v6_to_v4(nat46, &xlate_dst->local, &ip6h->daddr, pv4daddr);
   }
-  if (xlate_dst >= 0) {
-    if (xlate_src < 0) {
+  if (xlate_src)
+  {
+    xlate_v6_to_v4(nat46, &xlate_src->remote, &ip6h->saddr, pv4saddr);
+  }
+
+  if (xlate_dst != NULL) {
+    if (xlate_src == NULL) {
       if(proto == NEXTHDR_ICMP) {
         /* RFC6145 Section 5.2 discussed about non-IPv4-translatable IPv6 addresses on the IPv6 headers,
          * and left the solution for stateless translation as future work.
          * RFC6791 has recommendations for this issue, but until that's implemented, silently drop this packet
          */
-        nat46debug(1, "[nat46] Could not translate remote address v6->v4, ipair %d, for ICMP6 drop this packet", ipair);
+        nat46debug(1, "[nat46] Could not translate remote address v6->v4 for ICMP6 drop this packet");
       } else {
-        nat46debug(5, "[nat46] Could not translate remote address v6->v4, ipair %d", ipair);
+        nat46debug(5, "[nat46] Could not translate remote address v6->v4");
       }
     }
   } else {
     nat46debug(1, "[nat46] Could not find a translation pair v6->v4 src %pI6c dst %pI6c", &ip6h->saddr, &ip6h->daddr);
   }
-  nat46debug(5, "[nat46] pairs_xlate_v6_to_v4_outer result src %d dst %d", xlate_src, xlate_dst);
-  return ( (xlate_src >= 0) && (xlate_dst >= 0) );
+
+  nat46debug(5, "[nat46] pairs_xlate_v6_to_v4_outer result src %p dst %p", xlate_src, xlate_dst);
+  return (xlate_src && xlate_dst);
 }
 
 
@@ -1809,36 +1822,28 @@ static int ip4_input_not_interested(nat46_instance_t *nat46, struct iphdr *iph, 
 }
 
 static int pairs_xlate_v4_to_v6_outer(nat46_instance_t *nat46, struct iphdr *hdr4, uint16_t *sport, uint16_t *dport, void *v6saddr, void *v6daddr) {
-  int ipair = 0;
-  nat46_xlate_rulepair_t *apair = NULL;
-  int xlate_src = -1;
-  int xlate_dst = -1;
+  nat46_xlate_rulepair_t *xlate_src = NULL;
+  nat46_xlate_rulepair_t *xlate_dst = NULL;
+  struct in_addr src_addr;
+  struct in_addr dst_addr;
 
-  for(ipair = 0; ipair < nat46->npairs; ipair++) {
-    apair = &nat46->pairs[ipair];
+  src_addr.s_addr = hdr4->saddr;
+  dst_addr.s_addr = hdr4->daddr;
 
-    if(-1 == xlate_src) {
-      if(xlate_v4_to_v6(nat46, &apair->local, &hdr4->saddr, v6saddr, sport)) {
-        xlate_src = ipair;
-      }
-    }
-    if(-1 == xlate_dst) {
-      if(xlate_v4_to_v6(nat46, &apair->remote, &hdr4->daddr, v6daddr, dport)) {
-        xlate_dst = ipair;
-      }
-    }
-    if( (xlate_src >= 0) && (xlate_dst >= 0) ) {
-      break;
-    } else {
-      /* We did not match fully and there are more rules */
-      if((ipair+1 < nat46->npairs) && is_last_pair_in_group(apair)) {
-        xlate_src = -1;
-        xlate_dst = -1;
-      }
-    }
+  xlate_src = tree46_find_best_v4(&nat46->rules, src_addr);
+  xlate_dst = tree46_find_best_v4(&nat46->rules, dst_addr);
+
+  if(xlate_src)
+  {
+    xlate_v4_to_v6(nat46, &xlate_src->local, &hdr4->saddr, v6saddr, sport);
   }
-  nat46debug(5, "[nat46] pairs_xlate_v4_to_v6_outer result: src %d dst %d", xlate_src, xlate_dst);
-  if ( (xlate_src >= 0) && (xlate_dst >= 0) ) {
+  if(xlate_dst)
+  {
+    xlate_v4_to_v6(nat46, &xlate_dst->remote, &hdr4->daddr, v6daddr, dport);
+  }
+
+  nat46debug(5, "[nat46] pairs_xlate_v4_to_v6_outer result: src %p dst %p", xlate_src, xlate_dst);
+  if (xlate_src != NULL && xlate_dst != NULL) {
     return 1;
   }
 
@@ -1994,3 +1999,13 @@ done:
 }
 
 
+int nat46_rule_equal(nat46_xlate_rulepair_t *a, nat46_xlate_rulepair_t *b)
+{
+  if (memcmp(&a->local, &b->local, sizeof(a->local)) != 0) {
+    return 0;
+  }
+  if (memcmp(&a->remote, &b->remote, sizeof(a->remote)) != 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -219,6 +219,7 @@ static int try_parse_rule_arg(nat46_xlate_rule_t *rule, char *arg_name, char **p
 }
 
 int nat46_insert_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  unsigned long flags;
   int v4 = 0;
   int v6 = 0;
   if (rule->local.v4_pref_len == 0)
@@ -229,11 +230,14 @@ int nat46_insert_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   {
     v6 = 1;
   }
+  write_lock_irqsave(&nat46->rule_lock, flags);
   tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  write_unlock_irqrestore(&nat46->rule_lock, flags);
   return 0;
 }
 
 int nat46_set_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  unsigned long flags;
   int v4 = 0;
   int v6 = 0;
   nat46_xlate_rulepair_t *old_entry;
@@ -245,16 +249,19 @@ int nat46_set_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   {
     v6 = 1;
   }
+  write_lock_irqsave(&nat46->rule_lock, flags);
   old_entry = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
   if (tree46_remove(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len))
   {
     kfree(old_entry);
   }
   tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  write_unlock_irqrestore(&nat46->rule_lock, flags);
   return 0;
 }
 
 int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
+  unsigned long flags;
   int v4 = 0;
   int v6 = 0;
   nat46_xlate_rulepair_t *old_entry_v4;
@@ -267,6 +274,7 @@ int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   {
     v6 = 1;
   }
+  write_lock_irqsave(&nat46->rule_lock, flags);
   old_entry_v4 = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
   old_entry_v6 = tree46_find_best_v6(&nat46->rules, (v4) ? rule->remote.v6_pref : rule->local.v6_pref);
   if (old_entry_v4 == old_entry_v6)
@@ -276,6 +284,7 @@ int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
       kfree(old_entry_v4);
     }
   }
+  write_unlock_irqrestore(&nat46->rule_lock, flags);
   return 0;
 }
 
@@ -296,8 +305,7 @@ static char *xlate_style_to_string(nat46_xlate_style_t style) {
 /* 
  * Get the nat46 configuration into a supplied buffer (if non-null).
  */
-int nat46_get_config_string(nat46_instance_t *nat46, nat46_xlate_rulepair_t *pair, char *buf, int count) {
-  int ret = 0;
+int nat46_get_config_string(nat46_instance_t *nat46, const nat46_xlate_rulepair_t *pair, char *buf, int count) {  int ret = 0;
   char *format = "local.v4 %pI4/%d local.v6 %pI6c/%d local.style %s local.ea-len %d local.psid-offset %d remote.v4 %pI4/%d remote.v6 %pI6c/%d remote.style %s remote.ea-len %d remote.psid-offset %d debug %d";
 
   if (pair == NULL) {
@@ -412,7 +420,7 @@ From RFC6052, section 2.2:
 
 ********************************************************************/
 
-static void xlate_v4_to_nat64(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv4, void *pipv6) {
+static void xlate_v4_to_nat64(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv4, void *pipv6) {
   char *ipv4 = pipv4;
   char *ipv6 = pipv6;
 
@@ -453,7 +461,7 @@ static void xlate_v4_to_nat64(nat46_instance_t *nat46, nat46_xlate_rule_t *rule,
   }
 }
 
-static int xlate_nat64_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv6, void *pipv4) {
+static int xlate_nat64_to_v4(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv6, void *pipv4) {
   char *ipv4 = pipv4;
   char *ipv6 = pipv6;
   int cmp = -1;
@@ -637,7 +645,7 @@ bitarray_copy(const void *src_org, int src_offset, int src_len,
     }
 }
 
-static int xlate_map_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv4, void *pipv6, uint16_t *pl4id, int map_version) {
+static int xlate_map_v4_to_v6(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv4, void *pipv6, uint16_t *pl4id, int map_version) {
   int ret = 0;
   u32 *pv4u32 = pipv4;
   uint8_t *p6 = pipv6;
@@ -739,7 +747,7 @@ static int xlate_map_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule,
   return ret;
 }
 
-static int xlate_map_v6_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv6, void *pipv4, int version) {
+static int xlate_map_v6_to_v4(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv6, void *pipv4, int version) {
   uint8_t v4_lsb_bits_len = 32 - rule->v4_pref_len;
 
   if (memcmp(pipv6, &rule->v6_pref, rule->v6_pref_len/8)) {
@@ -774,7 +782,7 @@ static int xlate_map_v6_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule,
   return 1;
 }
 
-static int xlate_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv4, void *pipv6, uint16_t *pl4id) {
+static int xlate_v4_to_v6(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv4, void *pipv6, uint16_t *pl4id) {
   int ret = 0;
   switch(rule->style) {
     case NAT46_XLATE_NONE: /* always fail unless it is a host 1:1 translation */
@@ -799,7 +807,7 @@ static int xlate_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, voi
   return ret;
 }
 
-static int xlate_v6_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv6, void *pipv4) {
+static int xlate_v6_to_v4(nat46_instance_t *nat46, const nat46_xlate_rule_t *rule, void *pipv6, void *pipv4) {
   int ret = 0;
   switch(rule->style) {
     case NAT46_XLATE_NONE: /* always fail unless it is a host 1:1 translation */
@@ -957,14 +965,16 @@ static u16 rechecksum16(void *p, int count, u16 csum) {
 }
 
 /* Last rule in group must not have "none" as either source or destination */
-static int is_last_pair_in_group(nat46_xlate_rulepair_t *apair) {
+static int is_last_pair_in_group(const nat46_xlate_rulepair_t *apair) {
   return ( (apair->local.style != NAT46_XLATE_NONE) && (apair->remote.style != NAT46_XLATE_NONE) );
 }
 
 static void pairs_xlate_v6_to_v4_inner(nat46_instance_t *nat46, struct ipv6hdr *ip6h, __u32 *pv4saddr, __u32 *pv4daddr) {
   nat46_xlate_rulepair_t *xlate_src = NULL;
   nat46_xlate_rulepair_t *xlate_dst = NULL;
+  unsigned long flags;
 
+  read_lock_irqsave(&nat46->rule_lock, flags);
   xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
   xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
 
@@ -977,6 +987,7 @@ static void pairs_xlate_v6_to_v4_inner(nat46_instance_t *nat46, struct ipv6hdr *
     xlate_v6_to_v4(nat46, &xlate_src->local, &ip6h->saddr, pv4saddr);
   }
 
+  read_unlock_irqrestore(&nat46->rule_lock, flags);
   nat46debug(5, "[nat46payload] xlate results: src %p dst %p", xlate_src, xlate_dst);
 }
 
@@ -1562,7 +1573,9 @@ static uint16_t nat46_fixup_icmp(nat46_instance_t *nat46, struct iphdr *iph, str
 static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *ip6h, uint16_t proto, __u32 *pv4saddr, __u32 *pv4daddr) {
   nat46_xlate_rulepair_t *xlate_src = NULL;
   nat46_xlate_rulepair_t *xlate_dst = NULL;
+  unsigned long flags;
 
+  read_lock_irqsave(&nat46->rule_lock, flags);
   xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
   xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
   if(xlate_dst)
@@ -1573,6 +1586,7 @@ static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *i
   {
     xlate_v6_to_v4(nat46, &xlate_src->remote, &ip6h->saddr, pv4saddr);
   }
+  read_unlock_irqrestore(&nat46->rule_lock, flags);
 
   if (xlate_dst != NULL) {
     if (xlate_src == NULL) {
@@ -1826,10 +1840,12 @@ static int pairs_xlate_v4_to_v6_outer(nat46_instance_t *nat46, struct iphdr *hdr
   nat46_xlate_rulepair_t *xlate_dst = NULL;
   struct in_addr src_addr;
   struct in_addr dst_addr;
+  unsigned long flags;
 
   src_addr.s_addr = hdr4->saddr;
   dst_addr.s_addr = hdr4->daddr;
 
+  read_lock_irqsave(&nat46->rule_lock, flags);
   xlate_src = tree46_find_best_v4(&nat46->rules, src_addr);
   xlate_dst = tree46_find_best_v4(&nat46->rules, dst_addr);
 
@@ -1841,6 +1857,7 @@ static int pairs_xlate_v4_to_v6_outer(nat46_instance_t *nat46, struct iphdr *hdr
   {
     xlate_v4_to_v6(nat46, &xlate_dst->remote, &hdr4->daddr, v6daddr, dport);
   }
+  read_unlock_irqrestore(&nat46->rule_lock, flags);
 
   nat46debug(5, "[nat46] pairs_xlate_v4_to_v6_outer result: src %p dst %p", xlate_src, xlate_dst);
   if (xlate_src != NULL && xlate_dst != NULL) {

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -29,6 +29,14 @@
 #include "nat46-core.h"
 #include "nat46-module.h"
 
+static int reorder_threshold = 10;
+
+void
+nat46_set_reorder_threshold(nat46_instance_t *nat46, int new_threshold)
+{
+  reorder_threshold = new_threshold;
+}
+
 static void
 nat46debug_dump(nat46_instance_t *nat46, int level, void *addr, int len)
 {

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1565,9 +1565,11 @@ static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *i
   if (xlate_dst >= 0) {
     if (xlate_src < 0) {
       if(proto == NEXTHDR_ICMP) {
-        nat46debug(1, "[nat46] Could not translate remote address v6->v4, ipair %d, for ICMP6 use dest addr", ipair);
-        *pv4saddr = *pv4daddr;
-        xlate_src = xlate_dst;
+        /* RFC6145 Section 5.2 discussed about non-IPv4-translatable IPv6 addresses on the IPv6 headers,
+         * and left the solution for stateless translation as future work.
+         * RFC6791 has recommendations for this issue, but until that's implemented, silently drop this packet
+         */
+        nat46debug(1, "[nat46] Could not translate remote address v6->v4, ipair %d, for ICMP6 drop this packet", ipair);
       } else {
         nat46debug(5, "[nat46] Could not translate remote address v6->v4, ipair %d", ipair);
       }

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -228,69 +228,72 @@ static int try_parse_rule_arg(nat46_xlate_rule_t *rule, char *arg_name, char **p
 
 int nat46_insert_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   unsigned long flags;
-  int v4 = 0;
-  int v6 = 0;
-  if (rule->local.v4_pref_len == 0)
-  {
-    v4 = 1;
-  }
-  if (rule->local.v6_pref_len == 0)
-  {
-    v6 = 1;
-  }
+
   write_lock_irqsave(&nat46->rule_lock, flags);
-  tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  if (rule->local.v6_pref_len)
+  {
+    tree46_insert(&nat46->local_rules, rule->local.v4_pref, rule->local.v4_pref_len, rule->local.v6_pref, rule->local.v6_pref_len, rule);
+  }
+  else
+  {
+    tree46_insert(&nat46->remote_rules, rule->remote.v4_pref, rule->remote.v4_pref_len, rule->remote.v6_pref, rule->remote.v6_pref_len, rule);
+  }
   write_unlock_irqrestore(&nat46->rule_lock, flags);
   return 0;
 }
 
 int nat46_set_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   unsigned long flags;
-  int v4 = 0;
-  int v6 = 0;
-  nat46_xlate_rulepair_t *old_entry;
-  if (rule->local.v4_pref_len == 0)
-  {
-    v4 = 1;
-  }
-  if (rule->local.v6_pref_len == 0)
-  {
-    v6 = 1;
-  }
+
+  nat46_xlate_rulepair_t *old_local_v4_entry;
+  nat46_xlate_rulepair_t *old_remote_v4_entry;
+  nat46_xlate_rulepair_t *old_v6_entry;
+
   write_lock_irqsave(&nat46->rule_lock, flags);
-  old_entry = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
-  if (tree46_remove(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len))
+  if (rule->local.v6_pref_len)
   {
-    kfree(old_entry);
+    old_local_v4_entry = tree46_find_best_v4(&nat46->local_rules, rule->local.v4_pref);
+    old_v6_entry = tree46_find_best_v6(&nat46->local_rules, rule->local.v6_pref);
+    if (tree46_remove(&nat46->local_rules, rule->local.v4_pref, rule->local.v4_pref_len, rule->local.v6_pref, rule->local.v6_pref_len))
+      kfree(old_local_v4_entry);
   }
-  tree46_insert(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len, rule);
+  if (rule->remote.v6_pref_len)
+  {
+    old_remote_v4_entry = tree46_find_best_v4(&nat46->remote_rules, rule->remote.v4_pref);
+    old_v6_entry = tree46_find_best_v6(&nat46->remote_rules, rule->remote.v6_pref);
+    if (tree46_remove(&nat46->remote_rules, rule->remote.v4_pref, rule->remote.v4_pref_len,  rule->remote.v6_pref, rule->remote.v6_pref_len))
+      kfree(old_remote_v4_entry);
+  }
   write_unlock_irqrestore(&nat46->rule_lock, flags);
+  nat46_insert_config(nat46, rule);
   return 0;
 }
 
 int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule) {
   unsigned long flags;
-  int v4 = 0;
-  int v6 = 0;
-  nat46_xlate_rulepair_t *old_entry_v4;
+  nat46_xlate_rulepair_t *old_entry_local_v4;
+  nat46_xlate_rulepair_t *old_entry_remote_v4;
   nat46_xlate_rulepair_t *old_entry_v6;
-  if (rule->local.v4_pref_len == 0)
-  {
-    v4 = 1;
-  }
-  if (rule->local.v6_pref_len == 0)
-  {
-    v6 = 1;
-  }
+
   write_lock_irqsave(&nat46->rule_lock, flags);
-  old_entry_v4 = tree46_find_best_v4(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref);
-  old_entry_v6 = tree46_find_best_v6(&nat46->rules, (v4) ? rule->remote.v6_pref : rule->local.v6_pref);
-  if (old_entry_v4 == old_entry_v6)
+  old_entry_local_v4 = tree46_find_best_v4(&nat46->local_rules, rule->local.v4_pref);
+  old_entry_remote_v4 = tree46_find_best_v4(&nat46->remote_rules, rule->remote.v4_pref);
+  if (rule->local.v6_pref_len)
+    old_entry_v6 = tree46_find_best_v6(&nat46->local_rules, rule->local.v6_pref);
+  else
+    old_entry_v6 = tree46_find_best_v6(&nat46->remote_rules, rule->remote.v6_pref);
+  if (old_entry_local_v4 == old_entry_v6 ||
+      old_entry_remote_v4 == old_entry_v6)
   {
-    if (tree46_remove(&nat46->rules, (v4) ? rule->remote.v4_pref : rule->local.v4_pref, (v4) ? rule->remote.v4_pref_len : rule->local.v4_pref_len, (v6) ? rule->remote.v6_pref : rule->local.v6_pref, (v6) ? rule->remote.v6_pref_len : rule->local.v6_pref_len))
+    if (rule->local.v6_pref_len)
     {
-      kfree(old_entry_v4);
+      tree46_remove(&nat46->local_rules,  rule->local.v4_pref, rule->local.v4_pref_len, rule->local.v6_pref, rule->local.v6_pref_len);
     }
+    if (rule->remote.v6_pref_len)
+    {
+      tree46_remove(&nat46->remote_rules, rule->remote.v4_pref, rule->remote.v4_pref_len, rule->remote.v6_pref, rule->remote.v6_pref_len);
+    }
+    kfree(old_entry_v6);
   }
   write_unlock_irqrestore(&nat46->rule_lock, flags);
   return 0;
@@ -983,8 +986,8 @@ static void pairs_xlate_v6_to_v4_inner(nat46_instance_t *nat46, struct ipv6hdr *
   unsigned long flags;
 
   read_lock_irqsave(&nat46->rule_lock, flags);
-  xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
-  xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
+  xlate_src = tree46_find_best_v6(&nat46->local_rules, ip6h->saddr);
+  xlate_dst = tree46_find_best_v6(&nat46->remote_rules, ip6h->daddr);
 
   if(xlate_dst)
   {
@@ -1584,8 +1587,9 @@ static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *i
   unsigned long flags;
 
   read_lock_irqsave(&nat46->rule_lock, flags);
-  xlate_src = tree46_find_best_v6(&nat46->rules, ip6h->saddr);
-  xlate_dst = tree46_find_best_v6(&nat46->rules, ip6h->daddr);
+  xlate_src = tree46_find_best_v6(&nat46->remote_rules, ip6h->saddr);
+  xlate_dst = tree46_find_best_v6(&nat46->local_rules, ip6h->daddr);
+
   if(xlate_dst)
   {
     xlate_v6_to_v4(nat46, &xlate_dst->local, &ip6h->daddr, pv4daddr);
@@ -1603,7 +1607,7 @@ static int pairs_xlate_v6_to_v4_outer(nat46_instance_t *nat46, struct ipv6hdr *i
          * and left the solution for stateless translation as future work.
          * RFC6791 has recommendations for this issue, but until that's implemented, silently drop this packet
          */
-        nat46debug(1, "[nat46] Could not translate remote address v6->v4 for ICMP6 drop this packet");
+        nat46debug(1, "[nat46] Could not translate remote address %pI6C->v4 for ICMP6 drop this packet", &ip6h->saddr);
       } else {
         nat46debug(5, "[nat46] Could not translate remote address v6->v4");
       }
@@ -1854,8 +1858,8 @@ static int pairs_xlate_v4_to_v6_outer(nat46_instance_t *nat46, struct iphdr *hdr
   dst_addr.s_addr = hdr4->daddr;
 
   read_lock_irqsave(&nat46->rule_lock, flags);
-  xlate_src = tree46_find_best_v4(&nat46->rules, src_addr);
-  xlate_dst = tree46_find_best_v4(&nat46->rules, dst_addr);
+  xlate_src = tree46_find_best_v4(&nat46->local_rules, src_addr);
+  xlate_dst = tree46_find_best_v4(&nat46->remote_rules, dst_addr);
 
   if(xlate_src)
   {

--- a/nat46/modules/nat46-core.h
+++ b/nat46/modules/nat46-core.h
@@ -64,6 +64,7 @@ typedef struct {
   int refcount;
   int debug;
 
+  rwlock_t rule_lock;
   struct tree46_s rules;
 } nat46_instance_t;
 
@@ -80,7 +81,7 @@ int nat46_insert_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule);
 int nat46_set_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule);
 
 /* nat46_get_config_string prints the command for this rule into buf */
-int nat46_get_config_string(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule, char *buf, int count);
+int nat46_get_config_string(nat46_instance_t *nat46, const nat46_xlate_rulepair_t *rule, char *buf, int count);
 
 int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule);
 

--- a/nat46/modules/nat46-core.h
+++ b/nat46/modules/nat46-core.h
@@ -66,6 +66,8 @@ typedef struct {
 
   rwlock_t rule_lock;
   struct tree46_s rules;
+  struct tree46_s local_rules;
+  struct tree46_s remote_rules;
 } nat46_instance_t;
 
 int nat46_ipv6_input(struct sk_buff *old_skb);

--- a/nat46/modules/nat46-core.h
+++ b/nat46/modules/nat46-core.h
@@ -85,6 +85,9 @@ int nat46_get_config_string(nat46_instance_t *nat46, const nat46_xlate_rulepair_
 
 int nat46_remove_config(nat46_instance_t *nat46, nat46_xlate_rulepair_t *rule);
 
+/* set the distance into the list before an active rule is brought to the front */
+void nat46_set_reorder_threshold(nat46_instance_t *nat46, int threshold);
+
 int nat46_rule_equal(nat46_xlate_rulepair_t *a, nat46_xlate_rulepair_t *b);
 
 char *get_next_arg(char **ptail);

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -180,6 +180,12 @@ static ssize_t nat46_proc_write(struct file *file, const char __user *buffer,
 			mutex_lock(&add_del_lock);
 			nat46_remove(net, devname, tail);
 			mutex_unlock(&add_del_lock);
+		} else if (0 == strcmp(arg_name, "reorder")) {
+			devname = get_devname(&tail);
+			printk(KERN_INFO "nat46: setting reorder limit to %s\n", tail);
+			mutex_lock(&add_del_lock);
+			nat46_reorder(net, devname, tail);
+			mutex_unlock(&add_del_lock);
 		}
 	}
 

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -271,6 +271,22 @@ int nat46_configure(struct net *net, char *devname, char *buf) {
 	return -1;
 }
 
+int nat46_reorder(struct net *net, char *devname, char *buf) {
+	struct net_device *dev;
+	nat46_instance_t *nat46;
+	int reorder_threshold;
+
+	if ((dev = find_dev(net, devname)) == NULL ||
+	   (nat46 = netdev_nat46_instance(dev)) == NULL) {
+		return -1;
+	}
+
+	if (sscanf(buf, "%d", &reorder_threshold) == 1) {
+		nat46_set_reorder_threshold(nat46, reorder_threshold);
+	}
+	return 0;
+}
+
 int nat46_remove(struct net *net, char *devname, char *buf) {
 	int ret = -1;
 	struct net_device *dev;

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -340,7 +340,8 @@ void nat64_show_all_configs(struct net *net, struct seq_file *m) {
 			args.nat46 = nat46;
 			seq_printf(m, "add %s\n", dev->name);
 			read_lock_irqsave(&nat46->rule_lock, flags);
-			tree46_walk(&nat46->rules, print_rule, &args);
+			tree46_walk(&nat46->local_rules, print_rule, &args);
+			tree46_walk(&nat46->remote_rules, print_rule, &args);
 			read_unlock_irqrestore(&nat46->rule_lock, flags);
 			seq_printf(m,"\n");
 		}

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -109,6 +109,8 @@ static void nat46_netdev_setup(struct net_device *dev)
 	nat46_netdev_priv_t *priv = netdev_priv(dev);
 	nat46_instance_t *nat46 = alloc_nat46_instance();
 
+	rwlock_init(&nat46->rule_lock);
+
 	memset(priv, 0, sizeof(*priv));
 	priv->sig = NAT46_DEVICE_SIGNATURE;
 	priv->nat46 = nat46;

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -317,14 +317,13 @@ struct print_rule_args_s {
 	nat46_instance_t *nat46;
 };
 
+static char rulebuf[1024];
+
 static void print_rule(void *arg1, void *arg2) {
 	struct print_rule_args_s *args = (struct print_rule_args_s *)arg1;
 	nat46_xlate_rulepair_t *pair = (nat46_xlate_rulepair_t *)arg2;
-	int buflen = 1024;
-	char *buf = kmalloc(buflen+1, GFP_KERNEL);
-	nat46_get_config_string(args->nat46, pair, buf, buflen);
-	seq_printf (args->m, "insert %s %s\n", args->dev->name, buf);
-	kfree(buf);
+	nat46_get_config_string(args->nat46, pair, rulebuf, sizeof(rulebuf) - 1);
+	seq_printf (args->m, "insert %s %s\n", args->dev->name, rulebuf);
 }
 
 void nat64_show_all_configs(struct net *net, struct seq_file *m) {

--- a/nat46/modules/nat46-netdev.h
+++ b/nat46/modules/nat46-netdev.h
@@ -21,6 +21,7 @@ int nat46_destroy(struct net *net, char *devname);
 int nat46_insert(struct net *net, char *devname, char *buf);
 int nat46_configure(struct net *net, char *devname, char *buf);
 int nat46_remove(struct net *net, char *devname, char *buf);
+int nat46_reorder(struct net *net, char *devname, char *buf);
 void nat46_destroy_all(struct net *net);
 void nat64_show_all_configs(struct net *net, struct seq_file *m);
 void nat46_netdev_count_xmit(struct sk_buff *skb, struct net_device *dev);

--- a/nat46/modules/nat46-tree.c
+++ b/nat46/modules/nat46-tree.c
@@ -1,0 +1,302 @@
+#include "nat46-tree.h"
+
+struct tree4_s {
+    struct in_addr addr;
+    uint8_t plen;
+    struct tree4_s *left, *right;
+    void *priv;
+};
+
+struct tree6_s {
+    struct in6_addr addr;
+    uint8_t plen;
+    struct tree6_s *left, *right;
+    void *priv;
+};
+
+bool v4_addr_bit(struct in_addr addr, uint8_t bit)
+{
+    return !!(ntohl (addr.s_addr) & (1ULL << (31 - bit)));
+}
+
+bool v6_addr_bit(struct in6_addr addr, uint8_t bit)
+{
+    return !!(addr.s6_addr[bit >> 3] & (1ULL << (7 - (bit % 8))));
+}
+
+struct tree4_s *tree4_create(struct in_addr addr, uint8_t plen)
+{
+    struct tree4_s *tmp = kzalloc(sizeof(struct tree4_s), GFP_KERNEL);
+    tmp->addr.s_addr = htonl((ntohl (addr.s_addr)) & (0xffffffff << (32 - plen)));
+    tmp->plen = plen;
+    return tmp;
+}
+
+struct tree6_s *tree6_create(struct in6_addr addr, uint8_t plen)
+{
+    int i = 0;
+    struct tree6_s *tmp = kzalloc(sizeof (struct tree6_s), GFP_KERNEL);
+    for (; i < 16; i++)
+    {
+        if ((plen >> 3) > i)
+        {
+            tmp->addr.s6_addr[i] = addr.s6_addr[i];
+        }
+        else if ((plen >> 3) == i)
+        {
+            tmp->addr.s6_addr[i] = (addr.s6_addr[i] & (0xff << (8 - (plen % 8))));
+        }
+        else
+        {
+            tmp->addr.s6_addr[i] = 0x0;
+        }
+    }
+    tmp->plen = plen;
+    return tmp;
+}
+
+static bool tree46_insert_v4(struct tree4_s *tree, struct in_addr addr, uint8_t plen, void *priv)
+{
+    if (tree->plen == plen)
+    {
+        /* Insert here, or there is a conflict */
+        if (tree->priv == NULL)
+        {
+            tree->priv = priv;
+            return true;
+        }
+        return false;
+    }
+    if (v4_addr_bit (addr, tree->plen))
+    {
+        /* Go right */
+        if (tree->right == NULL)
+        {
+            /* Insert here */
+            tree->right = tree4_create(addr, tree->plen + 1);
+        }
+        return tree46_insert_v4(tree->right, addr, plen, priv);
+    }
+    else
+    {
+        /* Go left */
+        if (tree->left == NULL)
+        {
+            /* Insert here */
+            tree->left = tree4_create(addr, tree->plen + 1);
+        }
+        return tree46_insert_v4(tree->left, addr, plen, priv);
+    }
+}
+
+static bool tree46_remove_v4(struct tree4_s **tree, struct in_addr addr, uint8_t plen)
+{
+    bool res = false;
+    if (*tree == NULL)
+    {
+        return false;
+    }
+    if ((*tree)->plen == plen)
+    {
+        /* Disconnect this element */
+        (*tree)->priv = NULL;
+        res = true;
+    }
+    else
+    {
+        if (v4_addr_bit (addr, (*tree)->plen))
+        {
+            res = tree46_remove_v4(&((*tree)->right), addr, plen);
+        }
+        else
+        {
+            res = tree46_remove_v4(&((*tree)->left), addr, plen);
+        }
+    }
+    if (res)
+    {
+        /* If we have no children, cleanup */
+        if ((*tree)->priv == NULL && (*tree)->right == NULL && (*tree)->left == NULL)
+        {
+            struct tree4_s *tmp = *tree;
+            *tree = NULL;
+            kfree(tmp);
+        }
+    }
+    return res;
+}
+
+static bool tree46_insert_v6(struct tree6_s *tree, struct in6_addr addr, uint8_t plen, void *priv)
+{
+    if (tree->plen == plen)
+    {
+        /* Insert here, or there is a conflict */
+        if (tree->priv == NULL)
+        {
+            tree->priv = priv;
+            return true;
+        }
+        return false;
+    }
+    if (v6_addr_bit(addr, tree->plen))
+    {
+        /* Go right */
+        if (tree->right == NULL)
+        {
+            /* Insert here */
+            tree->right = tree6_create(addr, tree->plen + 1);
+        }
+        return tree46_insert_v6(tree->right, addr, plen, priv);
+    }
+    else
+    {
+        /* Go left */
+        if (tree->left == NULL)
+        {
+            /* Insert here */
+            tree->left = tree6_create(addr, tree->plen + 1);
+        }
+        return tree46_insert_v6(tree->left, addr, plen, priv);
+    }
+}
+
+static bool tree46_remove_v6(struct tree6_s **tree, struct in6_addr addr, uint8_t plen)
+{
+    bool res = false;
+    if (*tree == NULL)
+    {
+        return false;
+    }
+    if ((*tree)->plen == plen)
+    {
+        /* Disconnect this element */
+        (*tree)->priv = NULL;
+        res = true;
+    }
+    else
+    {
+        if (v6_addr_bit (addr, (*tree)->plen))
+        {
+            res = tree46_remove_v6(&((*tree)->right), addr, plen);
+        }
+        else
+        {
+            res = tree46_remove_v6(&((*tree)->left), addr, plen);
+        }
+    }
+    if (res)
+    {
+        /* If we have no children, cleanup */
+        if ((*tree)->priv == NULL && (*tree)->right == NULL && (*tree)->left == NULL)
+        {
+            struct tree6_s *tmp = *tree;
+            *tree = NULL;
+            kfree (tmp);
+        }
+    }
+    return res;
+}
+
+bool tree46_insert(struct tree46_s *tree, struct in_addr addr4, uint8_t plen4, struct in6_addr addr6, uint8_t plen6, void *priv)
+{
+    if (tree->v4 == NULL)
+    {
+        tree->v4 = tree4_create(addr4, 0);
+    }
+    if (!tree46_insert_v4(tree->v4, addr4, plen4, priv))
+    {
+        return false;
+    }
+    if (tree->v6 == NULL)
+    {
+        tree->v6 = tree6_create(addr6, 0);
+    }
+    if (!tree46_insert_v6(tree->v6, addr6, plen6, priv))
+    {
+        tree46_remove_v4(&tree->v4, addr4, plen4);
+        return false;
+    }
+    return true;
+}
+
+bool tree46_remove(struct tree46_s *tree, struct in_addr addr4, uint8_t plen4, struct in6_addr addr6, uint8_t plen6)
+{
+    bool ret = false;
+    if (tree46_remove_v4(&tree->v4, addr4, plen4))
+    {
+        ret = true;
+    }
+    if (tree46_remove_v6(&tree->v6, addr6, plen6))
+    {
+        ret = true;
+    }
+    return ret;
+}
+
+void *tree46_find_best_v4(struct tree46_s *tree, struct in_addr addr4)
+{
+    struct tree4_s *temp4 = tree->v4;
+    void *last_priv = NULL;
+    uint8_t lvl = 0;
+    for (; temp4 && lvl <= 32; lvl++)
+    {
+        if (temp4->priv)
+        {
+            last_priv = temp4->priv;
+        }
+        if (v4_addr_bit (addr4, lvl))
+        {
+            temp4 = temp4->right;
+        }
+        else
+        {
+            temp4 = temp4->left;
+        }
+    }
+    return last_priv;
+}
+
+void *tree46_find_best_v6(struct tree46_s *tree, struct in6_addr addr6)
+{
+    struct tree6_s *temp6 = tree->v6;
+    void *last_priv = NULL;
+    uint8_t lvl = 0;
+    for (; temp6 && lvl <= 128; lvl++)
+    {
+        if (temp6->priv)
+        {
+            last_priv = temp6->priv;
+        }
+        if (v6_addr_bit(addr6, lvl))
+        {
+            temp6 = temp6->right;
+        }
+        else
+        {
+            temp6 = temp6->left;
+        }
+    }
+    return last_priv;
+}
+
+static void tree46_walk_v4(struct tree4_s *t, void (*fn)(void *, void *), void *priv)
+{
+    if (t == NULL)
+    {
+        return;
+    }
+    if (t->priv)
+    {
+        fn(priv, t->priv);
+    }
+    tree46_walk_v4(t->left, fn, priv);
+    tree46_walk_v4(t->right, fn, priv);
+}
+
+void tree46_walk(struct tree46_s *tree, void (*fn)(void *, void *), void *priv)
+{
+    if (tree != NULL)
+    {
+        tree46_walk_v4(tree->v4, fn, priv);
+    }
+}

--- a/nat46/modules/nat46-tree.c
+++ b/nat46/modules/nat46-tree.c
@@ -26,7 +26,7 @@ bool v6_addr_bit(struct in6_addr addr, uint8_t bit)
 
 struct tree4_s *tree4_create(struct in_addr addr, uint8_t plen)
 {
-    struct tree4_s *tmp = kzalloc(sizeof(struct tree4_s), GFP_KERNEL);
+    struct tree4_s *tmp = kzalloc(sizeof(struct tree4_s), GFP_ATOMIC);
     tmp->addr.s_addr = htonl((ntohl (addr.s_addr)) & (0xffffffff << (32 - plen)));
     tmp->plen = plen;
     return tmp;
@@ -35,7 +35,7 @@ struct tree4_s *tree4_create(struct in_addr addr, uint8_t plen)
 struct tree6_s *tree6_create(struct in6_addr addr, uint8_t plen)
 {
     int i = 0;
-    struct tree6_s *tmp = kzalloc(sizeof (struct tree6_s), GFP_KERNEL);
+    struct tree6_s *tmp = kzalloc(sizeof (struct tree6_s), GFP_ATOMIC);
     for (; i < 16; i++)
     {
         if ((plen >> 3) > i)

--- a/nat46/modules/nat46-tree.h
+++ b/nat46/modules/nat46-tree.h
@@ -1,0 +1,12 @@
+#include "nat46-glue.h"
+
+struct tree46_s {
+    struct tree4_s *v4;
+    struct tree6_s *v6;
+};
+
+bool tree46_insert(struct tree46_s *tree, struct in_addr addr4, uint8_t plen4, struct in6_addr addr6, uint8_t plen6, void *priv);
+bool tree46_remove(struct tree46_s *tree, struct in_addr addr4, uint8_t plen4, struct in6_addr addr6, uint8_t plen6);
+void *tree46_find_best_v4(struct tree46_s *tree, struct in_addr addr4);
+void *tree46_find_best_v6(struct tree46_s *tree, struct in6_addr addr6);
+void tree46_walk(struct tree46_s *tree, void (*fn)(void *, void *), void *priv);


### PR DESCRIPTION
Re-apply all allied telesis changes on top of the latest nat46 fork. Note this is not all the commits, but rather the overall changes. Some commits were optimized out, as they were fix-ups of another. Instead I have squashed these together, such that the initial change was just correct to begin with. 